### PR TITLE
Stories on the main can survive Configuration Changes using VM

### DIFF
--- a/app/src/main/java/com/project/android_kidstories/Api/Api.java
+++ b/app/src/main/java/com/project/android_kidstories/Api/Api.java
@@ -1,5 +1,7 @@
 package com.project.android_kidstories.Api;
 
+import androidx.lifecycle.LiveData;
+
 import com.project.android_kidstories.Api.Responses.BaseResponse;
 import com.project.android_kidstories.Api.Responses.Category.CategoriesAllResponse;
 import com.project.android_kidstories.Api.Responses.bookmark.BookmarkResponse;

--- a/app/src/main/java/com/project/android_kidstories/ui/home/Fragments/CategoriesFragment.java
+++ b/app/src/main/java/com/project/android_kidstories/ui/home/Fragments/CategoriesFragment.java
@@ -10,6 +10,8 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Observer;
+import androidx.lifecycle.ViewModelProviders;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import com.project.android_kidstories.Api.Api;
@@ -25,6 +27,7 @@ import retrofit2.Response;
 public class CategoriesFragment extends Fragment {
     private RecyclerCategoryAdapter adapter;
     RecyclerView recyclerView;
+    StoryViewModel storyViewModel;
     private ProgressBar progressBar;
 
     public static CategoriesFragment newInstance() {
@@ -36,54 +39,13 @@ public class CategoriesFragment extends Fragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_categories, container, false);
-       /* recyclerView = v.findViewById(R.id.category_recycler);
-        GridLayoutManager layoutManager = new GridLayoutManager(getContext(), 2);
-        recyclerView.setLayoutManager(layoutManager);*/
-
-        // Glide.with(this).load("http://i.imgur.com/DvpvklR.png").into(imageView);
-
-       /* RecyclerStoriesAdapter recyclerAdapter = new RecyclerStoriesAdapter(getContext(), images, authors);
-        recyclerView.setAdapter(recyclerAdapter);*/
 
         progressBar = v.findViewById(R.id.category_bar);
 
-        progressBar.setVisibility(View.VISIBLE);
+        recyclerView = v.findViewById(R.id.category_recycler);
 
-        /*Create handle for the RetrofitInstance interface*/
-        Api service = RetrofitClient.getInstance().create(Api.class);
-        Call<CategoriesAllResponse> categories = service.getAllCategories();
-        Log.i("apple", "Size: " + categories.isExecuted());
-
-        categories.enqueue(new Callback<CategoriesAllResponse>() {
-            @Override
-            public void onResponse(Call<CategoriesAllResponse> call, Response<CategoriesAllResponse> response) {
-                //  generateCategoryList(response.body(),v);
-                progressBar.setVisibility(View.GONE);
-                recyclerView = v.findViewById(R.id.category_recycler);
-
-                if (response.isSuccessful()) {
-                    adapter = new RecyclerCategoryAdapter(getContext(), response.body());
-                    //LinearLayoutManager layoutManager = new LinearLayoutManager(getContext());
-                    int spanCount;
-                    try {
-                        spanCount = getContext().getResources().getInteger(R.integer.home_fragment_gridspan);
-                    } catch (NullPointerException e) {
-                        spanCount = 1;
-                    }
-                    GridLayoutManager layoutManager = new GridLayoutManager(getContext(), spanCount);
-                    recyclerView.setLayoutManager(layoutManager);
-                    recyclerView.setAdapter(adapter);
-                } else {
-
-                }
-            }
-
-            @Override
-            public void onFailure(Call<CategoriesAllResponse> call, Throwable t) {
-                progressBar.setVisibility(View.INVISIBLE);
-
-            }
-        });
+        storyViewModel = ViewModelProviders.of(this).get(StoryViewModel.class);
+        getCategories();
         return v;
     }
 
@@ -92,13 +54,20 @@ public class CategoriesFragment extends Fragment {
 
     }
 
-    /*Method to generate List of data using RecyclerView with custom adapter*/
-    private void generateCategoryList(CategoriesAllResponse categoryList, View view) {
-        recyclerView = view.findViewById(R.id.category_recycler);
-        adapter = new RecyclerCategoryAdapter(getContext(), categoryList);
-        GridLayoutManager layoutManager = new GridLayoutManager(getContext(), 2);
-        recyclerView.setLayoutManager(layoutManager);
-        recyclerView.setAdapter(adapter);
-    }
+    private void getCategories(){
+        Observer<CategoriesAllResponse> observe = categoriesAllResponse -> {
+            adapter = new RecyclerCategoryAdapter(getContext(), categoriesAllResponse);
+            int spanCount;
+            try {
+                spanCount = getContext().getResources().getInteger(R.integer.home_fragment_gridspan);
+            } catch (NullPointerException e) {
+                spanCount = 1;
+            }
+            GridLayoutManager layoutManager = new GridLayoutManager(getContext(), spanCount);
+            recyclerView.setLayoutManager(layoutManager);
+            recyclerView.setAdapter(adapter);
+        };
+        storyViewModel.getCategories().observe(this, observe);
 
+    }
 }

--- a/app/src/main/java/com/project/android_kidstories/ui/home/Fragments/NewStoriesFragment.java
+++ b/app/src/main/java/com/project/android_kidstories/ui/home/Fragments/NewStoriesFragment.java
@@ -10,16 +10,16 @@ import android.widget.ProgressBar;
 import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.lifecycle.Observer;
+import androidx.lifecycle.ViewModelProviders;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
-import com.pixplicity.easyprefs.library.Prefs;
 import com.project.android_kidstories.Api.Api;
 import com.project.android_kidstories.Api.Responses.bookmark.BookmarkResponse;
 import com.project.android_kidstories.Api.Responses.bookmark.UserBookmarkResponse;
 import com.project.android_kidstories.Api.Responses.story.StoryAllResponse;
-import com.project.android_kidstories.Api.RetrofitClient;
 import com.project.android_kidstories.DataStore.Repository;
 import com.project.android_kidstories.Model.Story;
 import com.project.android_kidstories.R;
@@ -34,17 +34,16 @@ import retrofit2.Response;
 
 import java.util.List;
 
-public class NewStoriesFragment extends BaseFragment implements StoryAdapter.OnStoryClickListener, View.OnClickListener, RecyclerStoriesAdapter.OnBookmarked, RecyclerStoriesAdapter.StorySearch {
+public class NewStoriesFragment extends BaseFragment implements StoryAdapter.OnStoryClickListener, View.OnClickListener,
+//        RecyclerStoriesAdapter.OnBookmarked,
+        RecyclerStoriesAdapter.StorySearch {
 
     private static final String TAG = "kidstories";
     private RecyclerView recyclerView;
     private RecyclerStoriesAdapter adapter;
     private ProgressBar progressBar;
     private Repository repository;
-    int initBookmarkId;
-    private Api service;
-    private boolean isAddSuccessful, initBookmark;
-    //    private StoryAdapter storyAdapter;
+    private StoryViewModel viewModel;
     private RecyclerStoriesAdapter storyAdapter;
     private String token;
     public static RecyclerStoriesAdapter.StorySearch storySearchListener;
@@ -60,97 +59,50 @@ public class NewStoriesFragment extends BaseFragment implements StoryAdapter.OnS
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_newstories, container, false);
         token = "Bearer " + new SharePref(getContext()).getMyToken();
+        RecyclerStoriesAdapter.token = token;
         repository = Repository.getInstance(getActivity().getApplication());
 
         progressBar = v.findViewById(R.id.new_stories_bar);
-        progressBar.setVisibility(View.VISIBLE);
+        progressBar.setVisibility(View.GONE);
         recyclerView = v.findViewById(R.id.recyclerView);
         refreshLayout = v.findViewById(R.id.swipe_refresh);
         refreshLayout.setRefreshing(true);
 
+        viewModel = ViewModelProviders.of(this.getActivity()).get(StoryViewModel.class);
+        viewModel.token = token;
+
         fetchStories();
+
+
 
         return v;
     }
 
     private void fetchStories(){
-        /*Create handle for the RetrofitInstance interface*/
-        service = RetrofitClient.getInstance().create(Api.class);
-        Call<StoryAllResponse> stories = service.getAllStoriesWithAuth(token);
+        Observer<StoryAllResponse> observer = storyAllResponse -> {
 
-        stories.enqueue(new Callback<StoryAllResponse>() {
-            @Override
-            public void onResponse(Call<StoryAllResponse> call, Response<StoryAllResponse> response) {
-                //  generateCategoryList(response.body(),v);
-                progressBar.setVisibility(View.GONE);
+            Log.d("XXXX  stories", storyAllResponse.getData().toString());
 
-                if (response.isSuccessful()) {
-                    storyAdapter = new RecyclerStoriesAdapter(getContext(), response.body(), NewStoriesFragment.this,repository);
-                    int spanCount;
-                    try {
-                        spanCount = getContext().getResources().getInteger(R.integer.home_fragment_gridspan);
-                    } catch (NullPointerException e) {
-                        spanCount = 1;
-                    }
-                    GridLayoutManager layoutManager = new GridLayoutManager(getContext(), spanCount);
-                    recyclerView.setLayoutManager(layoutManager);
-                    recyclerView.setAdapter(storyAdapter);
-                    refreshLayout.setRefreshing(false);
-                } else {
-
-                }
+            storyAdapter = new RecyclerStoriesAdapter(getContext(), storyAllResponse, repository);
+            int spanCount;
+            try {
+                spanCount = getContext().getResources().getInteger(R.integer.home_fragment_gridspan);
+            } catch (NullPointerException e) {
+                spanCount = 1;
             }
+            GridLayoutManager layoutManager = new GridLayoutManager(getContext(), spanCount);
+            recyclerView.setLayoutManager(layoutManager);
+            recyclerView.setAdapter(storyAdapter);
+            refreshLayout.setRefreshing(false);
+        };
+        viewModel.fetchStories().observe(this, observer);
 
-            @Override
-            public void onFailure(Call<StoryAllResponse> call, Throwable t) {
-                progressBar.setVisibility(View.INVISIBLE);
-
-            }
-        });
     }
 
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         refreshLayout.setOnRefreshListener(() -> fetchStories());
     }
-
-       /*
-        recyclerView = v.findViewById(R.id.new_story_frag_recycler);
-        recyclerView.setHasFixedSize(true);
-        recyclerView.setLayoutManager(new GridLayoutManager(getContext(), 2));*/
-
-        /*
-        ApiViewmodel apiViewmodel = ViewModelProviders.of(getActivity()).get(ApiViewmodel.class);
-        repository = apiViewmodel.getRepository();
-        storyAdapter = new StoryAdapter(apiViewmodel);
-        storyAdapter.setOnStoryClickListener(this);
-        recyclerView.setAdapter(storyAdapter);
-
-
-        fetchStories();*/
-
-    /*
-
-    private void fetchStories() {
-        if (!Common.checkNetwork(getActivity())) {
-            showToast("You do not have network connection");
-        }
-        repository.getApi().getAllStories().enqueue(new Callback<StoryAllResponse>() {
-            @Override
-            public void onResponse(Call<StoryAllResponse> call, Response<StoryAllResponse> response) {
-                if (response.isSuccessful()) {
-                    List<Story> storyList = response.body().getData();
-                    storyAdapter.summitStories(storyList);
-                    Log.d(TAG, "getAllStories Successful: Stories " + storyList.size());
-                }
-            }
-
-            @Override
-            public void onFailure(Call<StoryAllResponse> call, Throwable t) {
-                Log.w(TAG, "onFailure: " + t.getMessage());
-            }
-        });
-    }*/
 
     @Override
     public void onStoryClick(Story story) {
@@ -160,66 +112,6 @@ public class NewStoriesFragment extends BaseFragment implements StoryAdapter.OnS
     @Override
     public void onClick(View view) {
 
-    }
-
-    @Override
-    public boolean onBookmarkAdded(int storyId) {
-
-        Call<BookmarkResponse> addBookmark = service.bookmarkStory(token, storyId);
-        addBookmark.enqueue(new Callback<BookmarkResponse>() {
-            @Override
-            public void onResponse(Call<BookmarkResponse> call, Response<BookmarkResponse> response) {
-                if (response.isSuccessful()) {
-                    Common.updateSharedPref(storyId,true);
-                    Toast.makeText(getContext(), "Bookmark added", Toast.LENGTH_SHORT).show();
-                    isAddSuccessful = true;
-                } else {
-                    isAddSuccessful = false;
-                }
-            }
-
-            @Override
-            public void onFailure(Call<BookmarkResponse> call, Throwable t) {
-                isAddSuccessful = false;
-            }
-        });
-        Log.e("ISADDSUCCESSFUL", isAddSuccessful + "");
-        return isAddSuccessful;
-    }
-
-    @Override
-    public boolean isAlreadyBookmarked(int storyId, int pos) {
-
-        Call<UserBookmarkResponse> bookmarks = service.getUserBookmarks(token);
-
-        bookmarks.enqueue(new Callback<UserBookmarkResponse>() {
-            @Override
-            public void onResponse(Call<UserBookmarkResponse> call, Response<UserBookmarkResponse> response) {
-                if (response.isSuccessful()) {
-                    List<Story> data = response.body().getData();
-                    for (Story s : data) {
-                        if (s.getId() == storyId) {
-                            Log.e("STORYID", storyId + "");
-                            Common.updateSharedPref(storyId,true);
-                            initBookmark = true;
-                        }else{
-
-                            Common.updateSharedPref(storyId,false);
-                        }
-                    }
-                } else {
-
-                    Common.updateSharedPref(storyId,false);
-                }
-            }
-
-            @Override
-            public void onFailure(Call<UserBookmarkResponse> call, Throwable t) {
-                Toast.makeText(getContext(), "Something went wrong...Please try later!", Toast.LENGTH_SHORT).show();
-            }
-        });
-        Log.e("INITBOOKMARK", initBookmark + "");
-        return initBookmark;
     }
 
     @Override

--- a/app/src/main/java/com/project/android_kidstories/ui/home/Fragments/StoryViewModel.java
+++ b/app/src/main/java/com/project/android_kidstories/ui/home/Fragments/StoryViewModel.java
@@ -1,0 +1,80 @@
+package com.project.android_kidstories.ui.home.Fragments;
+
+import android.util.Log;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+import com.project.android_kidstories.Api.Api;
+import com.project.android_kidstories.Api.Responses.Category.CategoriesAllResponse;
+import com.project.android_kidstories.Api.Responses.story.StoryAllResponse;
+import com.project.android_kidstories.Api.RetrofitClient;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class StoryViewModel extends ViewModel {
+
+    private Api service;
+    public String token;
+    private MutableLiveData<StoryAllResponse> _response = new MutableLiveData<>();
+    private MutableLiveData<CategoriesAllResponse> _responseCategories = new MutableLiveData<>();
+
+
+    public LiveData<CategoriesAllResponse> getCategories(){
+        service = RetrofitClient.getInstance().create(Api.class);
+        Call<CategoriesAllResponse> categories = service.getAllCategories();
+        categories.enqueue(new Callback<CategoriesAllResponse>() {
+            @Override
+            public void onResponse(Call<CategoriesAllResponse> call, Response<CategoriesAllResponse> response) {
+
+                Log.d("XXX cat success", String.valueOf(response.isSuccessful()));
+                Log.d("XXX cat body", String.valueOf(response.body().getData()));
+
+                if (response.isSuccessful()) {
+
+
+                    _responseCategories.postValue(response.body());
+
+                }
+            }
+                @Override
+                public void onFailure(Call<CategoriesAllResponse> call, Throwable t) {
+//                progressBar.setVisibility(View.INVISIBLE);
+
+                }
+            });
+
+       return _responseCategories;
+
+        }
+
+    public LiveData<StoryAllResponse> fetchStories(String page){
+        /*Create handle for the RetrofitInstance interface*/
+        service = RetrofitClient.getInstance().create(Api.class);
+        Call<StoryAllResponse> stories = service.getAllStoriesWithAuth(token, page);
+//        Log.i("apple", "Size: " + categories.isExecuted());
+
+        stories.enqueue(new Callback<StoryAllResponse>() {
+            @Override
+            public void onResponse(Call<StoryAllResponse> call, Response<StoryAllResponse> response) {
+
+                Log.d("XXXX", response.message());
+
+                if (response.isSuccessful()) {
+
+                    Log.d("XXXX", response.body().getStories().toString());
+
+                    _response.postValue(response.body());
+                }
+            }
+
+            @Override
+            public void onFailure(Call<StoryAllResponse> call, Throwable t) {
+
+            }
+
+
+        });
+        return _response;
+    }
+}

--- a/app/src/main/java/com/project/android_kidstories/ui/home/HomeViewModel.java
+++ b/app/src/main/java/com/project/android_kidstories/ui/home/HomeViewModel.java
@@ -1,10 +1,26 @@
 package com.project.android_kidstories.ui.home;
 
+import android.view.View;
+
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
+import androidx.recyclerview.widget.GridLayoutManager;
+
+import com.project.android_kidstories.Api.Api;
+import com.project.android_kidstories.Api.Responses.story.StoryAllResponse;
+import com.project.android_kidstories.Api.RetrofitClient;
+import com.project.android_kidstories.R;
+import com.project.android_kidstories.adapters.RecyclerStoriesAdapter;
+import com.project.android_kidstories.ui.home.Fragments.NewStoriesFragment;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 public class HomeViewModel extends ViewModel {
+
+
 
     private MutableLiveData<String> mText;
 
@@ -16,4 +32,7 @@ public class HomeViewModel extends ViewModel {
     public LiveData<String> getText() {
         return mText;
     }
+
+
+
 }

--- a/app/src/main/java/com/project/android_kidstories/ui/profile/MyStoriesFragment.java
+++ b/app/src/main/java/com/project/android_kidstories/ui/profile/MyStoriesFragment.java
@@ -66,6 +66,7 @@ public class MyStoriesFragment extends Fragment {
         sharePref = SharePref.getINSTANCE(getActivity().getApplicationContext());
 
 
+
         repository = new Repository(getActivity().getApplicationContext());
         repository.getStoryApi().getAllStories().enqueue(new Callback<StoryAllResponse>() {
             @Override


### PR DESCRIPTION
A clean code should be top priority after functionality.

i used a VM to store data for fragments on the Main Menu. This solved the problem of unwanted reloading of data after mere configuration change like screen rotation